### PR TITLE
Chore(design-tokens): Remove `prepare` script

### DIFF
--- a/packages/design-tokens/package.json
+++ b/packages/design-tokens/package.json
@@ -22,7 +22,6 @@
     "format": "yarn format:check",
     "format:check": "prettier --check ./",
     "format:fix": "prettier --write ./",
-    "prepare": "husky install",
     "lint": "stylelint --config ../../.stylelintrc.js ./src/**/*.scss",
     "test": "yarn lint"
   },


### PR DESCRIPTION
  * `prepare` script and husky usage is defined in root package.json