### PR TITLE
Chore(repo): Set codeowners to GitHub team (refs #DS-389)

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,4 +1,4 @@
 # Code owners for jobs-design-tokens
 # https://help.github.com/en/articles/about-code-owners
 
-* @adamkudrna @crishpeen @lmc-eu/frontend-developers
+* @lmc-eu/jobs-design-system


### PR DESCRIPTION
  * @see: https://github.com/orgs/lmc-eu/teams/jobs-design-system