### PR TITLE
JALL-448: Update scripts generating icons

### DIFF
--- a/packages/icons/scripts/buildConstants.js
+++ b/packages/icons/scripts/buildConstants.js
@@ -2,13 +2,14 @@ const fs = require('fs');
 const path = require('path');
 // eslint-disable-next-line import/no-extraneous-dependencies
 const jsdom = require('jsdom');
+const { filterSvgFiles } = require('./shared');
 
 const svgSrcDir = path.resolve(__dirname, `../dist/svg`);
 const distFile = path.resolve(__dirname, `../dist/icons.js`);
 
 const buildContants = (srcDir, file) => {
   fs.readdir(srcDir, (err, files) => {
-    const svgs = files.filter((el) => path.extname(el) === '.svg');
+    const svgs = filterSvgFiles(files);
 
     if (svgs.length > 0) {
       const icons = {};

--- a/packages/icons/scripts/buildSvg.js
+++ b/packages/icons/scripts/buildSvg.js
@@ -5,30 +5,32 @@ const { filterSvgFiles } = require('./shared');
 const svgSrcDir = path.resolve(__dirname, `../src/svg`);
 const svgDistDir = path.resolve(__dirname, `../dist/svg`);
 
+const normalizeSvgColors = (fileName, svgContent) =>
+  fileName.endsWith('-colored.svg') ? svgContent : svgContent.replace(/fill="#\w+"/g, 'fill="currentColor"');
+
 const normalizeAndCopySvg = (srcDir, distDir) => {
   fs.readdir(srcDir, (err, files) => {
     const svgs = filterSvgFiles(files);
 
-      if (svgs.length > 0) {
-        let sprite = '<svg xmlns="http://www.w3.org/2000/svg" style="display: none;">\n';
-        const spriteDistFile = path.join(distDir, 'sprite.svg');
+    if (svgs.length > 0) {
+      let sprite = '<svg xmlns="http://www.w3.org/2000/svg" style="display: none;">\n';
+      const spriteDistFile = path.join(distDir, 'sprite.svg');
 
-        svgs.forEach((svg) => {
-          const svgPath = path.join(srcDir, svg);
-          const svgDistPath = path.join(distDir, svg);
-          const svgContent = fs.readFileSync(svgPath, 'utf8');
-          const svgContentFixed = svgContent.replace(/fill="#\w+"/g, 'fill="currentColor"');
-          const svgSpriteContent = svgContentFixed
-            .replace(/<svg.*(viewBox="(\d+\s){3}\d+").*>/, `<symbol id="${svg.slice(0, -4)}" $1>`)
-            .replace(/<\/svg>/g, '</symbol>');
-          sprite += svgSpriteContent;
-          fs.writeFileSync(path.join(svgDistPath), svgContentFixed);
-        });
+      svgs.forEach((svg) => {
+        const svgPath = path.join(srcDir, svg);
+        const svgDistPath = path.join(distDir, svg);
+        const svgContent = fs.readFileSync(svgPath, 'utf8');
+        const svgContentNormalized = normalizeSvgColors(svg, svgContent);
+        const svgSpriteContent = svgContentNormalized
+          .replace(/<svg.*(viewBox="(\d+\s){3}\d+").*>/, `<symbol id="${svg.slice(0, -4)}" $1>`)
+          .replace(/<\/svg>/g, '</symbol>');
+        sprite += svgSpriteContent;
+        fs.writeFileSync(path.join(svgDistPath), svgContentNormalized);
+      });
 
-        sprite += '</svg>';
+      sprite += '</svg>';
 
-        fs.writeFileSync(spriteDistFile, sprite);
-      }
+      fs.writeFileSync(spriteDistFile, sprite);
     }
   });
 };

--- a/packages/icons/scripts/buildSvg.js
+++ b/packages/icons/scripts/buildSvg.js
@@ -1,13 +1,13 @@
 const fs = require('fs');
 const path = require('path');
+const { filterSvgFiles } = require('./shared');
 
 const svgSrcDir = path.resolve(__dirname, `../src/svg`);
 const svgDistDir = path.resolve(__dirname, `../dist/svg`);
 
 const normalizeAndCopySvg = (srcDir, distDir) => {
   fs.readdir(srcDir, (err, files) => {
-    if (files?.length > 0) {
-      const svgs = files.filter((el) => path.extname(el) === '.svg');
+    const svgs = filterSvgFiles(files);
 
       if (svgs.length > 0) {
         let sprite = '<svg xmlns="http://www.w3.org/2000/svg" style="display: none;">\n';

--- a/packages/icons/scripts/prepareSvgReact.js
+++ b/packages/icons/scripts/prepareSvgReact.js
@@ -14,7 +14,7 @@ const toPascalCase = (string) =>
 
 const prepareSvgForReactComponent = (srcDir, distDir) => {
   fs.readdir(srcDir, (err, files) => {
-    const svgs = files.filter((el) => path.extname(el) === '.svg');
+    const svgs = files.filter((el) => path.extname(el) === '.svg' && el !== 'sprite.svg');
     if (svgs.length > 0) {
       svgs.forEach((svg) => {
         const svgPath = path.join(srcDir, svg);

--- a/packages/icons/scripts/shared.js
+++ b/packages/icons/scripts/shared.js
@@ -1,0 +1,8 @@
+const path = require('path');
+
+const filterSvgFiles = (fileNames) =>
+  fileNames.filter((fileName) => path.extname(fileName) === '.svg' && fileName !== 'sprite.svg');
+
+module.exports = {
+  filterSvgFiles,
+};


### PR DESCRIPTION
Currently we don't share code generator for icons. We would like to have our scripts same as in the Spirit codebase and be able to generate colored icons.

Code has been copied from the https://github.com/lmc-eu/spirit-design-system/tree/main/packages/icons.